### PR TITLE
Hide Streamlit footer by fixing syntax error

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ footer {
 }
 </style>
 """
-st.write(hide_footer_style, unsafe_allow_html=True)
+st.markdown(hide_footer_style, unsafe_allow_html=True)
 
 query_params = st.experimental_get_query_params()
 mode = query_params.get("mode", ["uk"])[0]


### PR DESCRIPTION
Fixes #10. Must be tested in production.