### PR TITLE
Replaced st.experimental_get_query_params with st.query_params

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,8 +47,7 @@ footer {
 """
 st.markdown(hide_footer_style, unsafe_allow_html=True)
 
-query_params = st.query_params()
-mode = query_params.get("mode", ["uk"])[0]
+mode = st.query_params.get("mode", ["uk"])[0]
 
 if mode == "uk":
     with st.expander("Compute current-law taxes and benefits", expanded=True):

--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ footer {
 """
 st.markdown(hide_footer_style, unsafe_allow_html=True)
 
-query_params = st.experimental_get_query_params()
+query_params = st.query_params()
 mode = query_params.get("mode", ["uk"])[0]
 
 if mode == "uk":


### PR DESCRIPTION
Replaced st.experimental_get_query_params with st.query_params as st.experimental_get_query_params was deprecated. This ensures that the API demo app still works.
Fixes #6 